### PR TITLE
feat: winscp custom ini path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ Open site SSH console in 3 clicks
 - show config for remote debug site
 - try to write config for remote site in winscp.ini
 
-For Winscp.ini write you should open Options - Preferences - Storage - set Configuration storage - Automatic INI file
+For Winscp.ini write you should store your WinSCP settings in INI file.
+To do this, open Options - Preferences - Storage, and  set Configuration storage as "Automatic INI file" or "Custom INI file".
+In case Configuration Storage as "Custom INI file", open VSCode settings, and define setting "ansible-server-sites.winscp_ini_path"
 
 ## Extension Settings
 - `ansible-server-sites.json_url` - URL to your generated JSON with site list
 - `ansible-server-sites.json_cache_time` - cache time JSON data, in seconds
+- `ansible-server-sites.winscp_ini_path` - path to your WinSCP.ini file

--- a/extension.js
+++ b/extension.js
@@ -201,7 +201,8 @@ async function commandSiteConfigs(){
 
     // winscp.ini
     if(process.platform == 'win32'){
-        let winscpIniPath = process.env.APPDATA + '/winscp.ini';
+        const config = vscode.workspace.getConfiguration('ansible-server-sites');
+        const winscpIniPath = config.get('winscp_ini_path', process.env.APPDATA + '/winscp.ini');
         if(fs.existsSync(winscpIniPath)){
             answer = await vscode.window.showInformationMessage('Write winscp.ini?', {
                 title: 'Yes',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "ansible-server-sites",
     "displayName": "ansible-server-sites",
     "description": "Operations with sites deployed with viasite-ansible/ansible-server",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "publisher": "popstas",
     "engines": {
         "vscode": "^1.15.0"
@@ -48,6 +48,11 @@
                 "ansible-server-sites.json_cache_time": {
                     "type": "integer",
                     "description": "JSON cache time, seconds",
+                    "default": 3600
+                },
+                "ansible-server-sites.winscp_ini_path": {
+                    "type": "string",
+                    "description": "Path to WinSCP.ini file",
                     "default": 3600
                 }
             }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
                 "ansible-server-sites.winscp_ini_path": {
                     "type": "string",
                     "description": "Path to WinSCP.ini file",
-                    "default": 3600
+                    "default": ""
                 }
             }
         }


### PR DESCRIPTION
Add ability to use custom winscp.ini path by defining option in VSCode settings.
Without `ansible-server-sites.winscp_ini_path` setting will be used Automatic INI file path.